### PR TITLE
two small fixes

### DIFF
--- a/Hanabi.tex
+++ b/Hanabi.tex
@@ -732,7 +732,7 @@ For example, if a played is clued on a \Y{2} and a \Y{4}, and they already had a
 		\task[E] \CARD[c]{W3} \CARD[c]{W5} \CARD{G3} \CARD{Y1}
 	\end{tasks}
 	
-	A clues \W{S} to E. B, C, and D do something (i.e. B clues \Y{S} to D, C clues \Z{5} to A, D plays his \Y{3}), then E plays their \W{3}. It's A's turn again, and they discard. B sees that E's clued card is a \W{5}, hence it is not playable. Since A didn't give any fix clue, it must be a finesse, so B plays the card that was in finesse position when the \W{S} clue was given, which is a \R{2}. E sees that B's \W{4} was in finesse position at that moment, so they delay playing the \W{5} until the \W{4} is played.
+	A clues \W{S} to E. B, C, and D do something (e.g. B clues \Y{S} to D, C clues \Z{5} to A, D plays his \Y{3}), then E plays their \W{3}. It's A's turn again, and they discard. B sees that E's clued card is a \W{5}, hence it is not playable. Since A didn't give any fix clue, it must be a finesse, so B plays the card that was in finesse position when the \W{S} clue was given, which is a \R{2}. E sees that B's \W{4} was in finesse position at that moment, so they delay playing the \W{5} until the \W{4} is played.
 	
 \end{example}
 
@@ -1091,7 +1091,7 @@ This trick was worth a full point, but it can get even better.
 		\task[E] \CARD{W2} \CARD{B1} \CARD{R1} \CARD{G3}
 	\end{tasks}
 	
-	As before, A to play, no clues left, two cards in the deck, one \Y{4} has been discarded. B, C, and D have been permuted, and also A, not E, has the \M{5} in their hand. Notice that there is no way to point the \Y{4} in B's hand with one single clue.
+	As before, A to play, no clues left, two cards in the deck, one \Y{4} has been discarded. B, C, and D have been permuted, and also A, not E, has the \M{5} in their hand. Notice that there is no way to point the \Y{4} in C's hand with one single clue.
 	
 	A discards their third card from the left (the \R{2}). It may have been the \M{5}, but it was still worth the risk (see why?). B knows that their only relevant card is the \B{5}, so in particular they know that they must not play. Also, C has to play two cards, so B must not discard either. In this case, B clues \Z{5} to C. C plays the \Y{4} according to A's discard, then D plays their \B{4}, and E, with no clues left, discards their third card from the left (the \R{1}). A plays (accordingly) their \M{5} (which is now the third card from the left), B and C play their \Z{5}'s, and once again the players score a 30.
 \end{example}


### PR DESCRIPTION
Unrelated remarks:

I've seen this document floating around before, but now I finally read it. It is a very interesting set of conventions, with interesting similarities and differences between the [hanabi.live conventions](https://github.com/Zamiell/hanabi-conventions/blob/master/Reference.md). 

I'm curious about the history of these conventions. Some conventions are exactly the same as on hanabi.live, but with a different name (your *early save* and hanabi.live *5 chop move* or your *layered finesse* and hanabi.live *patch finesse*). Did one group take these conventions from the other group, or were these conventions mostly invented independently?

Also, have you played with the hanabi.live conventions? Do you have an idea how the strength of the conventions compare? I'm in particular interested about the strength of "play all cards until I give a stop clue" in your convention vs hanabi.live's "play leftmost only and keep the other cards in hand".

